### PR TITLE
Set statuses on workflows

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/workflow/workflow-trigger.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/workflow-trigger.resolver.ts
@@ -19,19 +19,19 @@ export class WorkflowTriggerResolver {
   ) {}
 
   @Mutation(() => Boolean)
-  async enableWorkflowTrigger(
+  async activateWorkflowVersion(
     @Args('workflowVersionId') workflowVersionId: string,
   ) {
-    return await this.workflowTriggerWorkspaceService.enableWorkflowTrigger(
+    return await this.workflowTriggerWorkspaceService.activateWorkflowVersion(
       workflowVersionId,
     );
   }
 
   @Mutation(() => Boolean)
-  async disableWorkflowTrigger(
+  async deactivateWorkflowVersion(
     @Args('workflowVersionId') workflowVersionId: string,
   ) {
-    return await this.workflowTriggerWorkspaceService.disableWorkflowTrigger(
+    return await this.workflowTriggerWorkspaceService.deactivateWorkflowVersion(
       workflowVersionId,
     );
   }

--- a/packages/twenty-server/src/modules/workflow/common/standard-objects/workflow-version.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/workflow/common/standard-objects/workflow-version.workspace-entity.ts
@@ -28,9 +28,10 @@ export enum WorkflowVersionStatus {
   DRAFT = 'DRAFT',
   ACTIVE = 'ACTIVE',
   DEACTIVATED = 'DEACTIVATED',
+  ARCHIVED = 'ARCHIVED',
 }
 
-export const WorkflowVersionStatusOptions = [
+const WorkflowVersionStatusOptions = [
   {
     value: WorkflowVersionStatus.DRAFT,
     label: 'Draft',
@@ -47,7 +48,13 @@ export const WorkflowVersionStatusOptions = [
     value: WorkflowVersionStatus.DEACTIVATED,
     label: 'Deactivated',
     position: 2,
-    color: 'gray',
+    color: 'red',
+  },
+  {
+    value: WorkflowVersionStatus.ARCHIVED,
+    label: 'Archived',
+    position: 3,
+    color: 'grey',
   },
 ];
 

--- a/packages/twenty-server/src/modules/workflow/common/standard-objects/workflow.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/workflow/common/standard-objects/workflow.workspace-entity.ts
@@ -20,9 +20,35 @@ import { WorkflowEventListenerWorkspaceEntity } from 'src/modules/workflow/commo
 import { WorkflowRunWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
 import {
   WorkflowVersionStatus,
-  WorkflowVersionStatusOptions,
   WorkflowVersionWorkspaceEntity,
 } from 'src/modules/workflow/common/standard-objects/workflow-version.workspace-entity';
+
+export enum WorkflowStatus {
+  DRAFT = 'DRAFT',
+  ACTIVE = 'ACTIVE',
+  DEACTIVATED = 'DEACTIVATED',
+}
+
+const WorkflowStatusOptions = [
+  {
+    value: WorkflowVersionStatus.DRAFT,
+    label: 'Draft',
+    position: 0,
+    color: 'yellow',
+  },
+  {
+    value: WorkflowVersionStatus.ACTIVE,
+    label: 'Active',
+    position: 1,
+    color: 'green',
+  },
+  {
+    value: WorkflowVersionStatus.DEACTIVATED,
+    label: 'Deactivated',
+    position: 2,
+    color: 'grey',
+  },
+];
 
 @WorkspaceEntity({
   standardId: STANDARD_OBJECT_IDS.workflow,
@@ -61,10 +87,10 @@ export class WorkflowWorkspaceEntity extends BaseWorkspaceEntity {
     type: FieldMetadataType.MULTI_SELECT,
     label: 'Statuses',
     description: 'The current statuses of the workflow versions',
-    options: WorkflowVersionStatusOptions,
+    options: WorkflowStatusOptions,
   })
   @WorkspaceIsNullable()
-  statuses: WorkflowVersionStatus[] | null;
+  statuses: WorkflowStatus[] | null;
 
   @WorkspaceField({
     standardId: WORKFLOW_STANDARD_FIELD_IDS.position,

--- a/packages/twenty-server/src/modules/workflow/common/workflow-common.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/common/workflow-common.workspace-service.ts
@@ -28,6 +28,16 @@ export class WorkflowCommonWorkspaceService {
       },
     });
 
+    return this.getValidWorkflowVersionOrFail(workflowVersion);
+  }
+
+  async getValidWorkflowVersionOrFail(
+    workflowVersion: WorkflowVersionWorkspaceEntity | null,
+  ): Promise<
+    Omit<WorkflowVersionWorkspaceEntity, 'trigger'> & {
+      trigger: WorkflowTrigger;
+    }
+  > {
     if (!workflowVersion) {
       throw new WorkflowTriggerException(
         'Workflow version not found',

--- a/packages/twenty-server/src/modules/workflow/workflow-status/jobs/__tests__/workflow-statuses-update.job.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-status/jobs/__tests__/workflow-statuses-update.job.spec.ts
@@ -4,9 +4,9 @@ import { TwentyORMManager } from 'src/engine/twenty-orm/twenty-orm.manager';
 import { WorkflowVersionStatus } from 'src/modules/workflow/common/standard-objects/workflow-version.workspace-entity';
 import { WorkflowStatus } from 'src/modules/workflow/common/standard-objects/workflow.workspace-entity';
 import {
-    WorkflowStatusesUpdateJob,
-    WorkflowVersionEvent,
-    WorkflowVersionEventType,
+  WorkflowStatusesUpdateJob,
+  WorkflowVersionBatchEvent,
+  WorkflowVersionEventType,
 } from 'src/modules/workflow/workflow-status/jobs/workflow-statuses-update.job';
 
 describe('WorkflowStatusesUpdate', () => {
@@ -60,10 +60,10 @@ describe('WorkflowStatusesUpdate', () => {
     describe('when event type is CREATE', () => {
       it('when already a draft, do not change anything', async () => {
         // Arrange
-        const event: WorkflowVersionEvent = {
+        const event: WorkflowVersionBatchEvent = {
           workspaceId: '1',
           type: WorkflowVersionEventType.CREATE,
-          workflowId: '1',
+          workflowIds: ['1'],
         };
 
         const mockWorkflow = {
@@ -82,10 +82,10 @@ describe('WorkflowStatusesUpdate', () => {
 
       it('when no draft yet, update statuses', async () => {
         // Arrange
-        const event: WorkflowVersionEvent = {
+        const event: WorkflowVersionBatchEvent = {
           workspaceId: '1',
           type: WorkflowVersionEventType.CREATE,
-          workflowId: '1',
+          workflowIds: ['1'],
         };
 
         const mockWorkflow = {
@@ -106,12 +106,16 @@ describe('WorkflowStatusesUpdate', () => {
     describe('when event type is STATUS_UPDATE', () => {
       test('when status is the same, should not do anything', async () => {
         // Arrange
-        const event: WorkflowVersionEvent = {
+        const event: WorkflowVersionBatchEvent = {
           workspaceId: '1',
           type: WorkflowVersionEventType.STATUS_UPDATE,
-          workflowId: '1',
-          previousStatus: WorkflowVersionStatus.ACTIVE,
-          newStatus: WorkflowVersionStatus.ACTIVE,
+          statusUpdates: [
+            {
+              workflowId: '1',
+              previousStatus: WorkflowVersionStatus.ACTIVE,
+              newStatus: WorkflowVersionStatus.ACTIVE,
+            },
+          ],
         };
 
         const mockWorkflow = {
@@ -130,12 +134,16 @@ describe('WorkflowStatusesUpdate', () => {
 
       test('when update that should be impossible, do not do anything', async () => {
         // Arrange
-        const event: WorkflowVersionEvent = {
+        const event: WorkflowVersionBatchEvent = {
           workspaceId: '1',
           type: WorkflowVersionEventType.STATUS_UPDATE,
-          workflowId: '1',
-          previousStatus: WorkflowVersionStatus.ACTIVE,
-          newStatus: WorkflowVersionStatus.DRAFT,
+          statusUpdates: [
+            {
+              workflowId: '1',
+              previousStatus: WorkflowVersionStatus.ACTIVE,
+              newStatus: WorkflowVersionStatus.DRAFT,
+            },
+          ],
         };
 
         const mockWorkflow = {
@@ -154,12 +162,16 @@ describe('WorkflowStatusesUpdate', () => {
 
       test('when WorkflowVersionStatus.DEACTIVATED to WorkflowVersionStatus.ACTIVE, should activate', async () => {
         // Arrange
-        const event: WorkflowVersionEvent = {
+        const event: WorkflowVersionBatchEvent = {
           workspaceId: '1',
           type: WorkflowVersionEventType.STATUS_UPDATE,
-          workflowId: '1',
-          previousStatus: WorkflowVersionStatus.DEACTIVATED,
-          newStatus: WorkflowVersionStatus.ACTIVE,
+          statusUpdates: [
+            {
+              workflowId: '1',
+              previousStatus: WorkflowVersionStatus.DEACTIVATED,
+              newStatus: WorkflowVersionStatus.ACTIVE,
+            },
+          ],
         };
 
         const mockWorkflow = {
@@ -181,12 +193,16 @@ describe('WorkflowStatusesUpdate', () => {
 
       test('when WorkflowVersionStatus.ACTIVE to WorkflowVersionStatus.DEACTIVATED, should deactivate', async () => {
         // Arrange
-        const event: WorkflowVersionEvent = {
+        const event: WorkflowVersionBatchEvent = {
           workspaceId: '1',
           type: WorkflowVersionEventType.STATUS_UPDATE,
-          workflowId: '1',
-          previousStatus: WorkflowVersionStatus.ACTIVE,
-          newStatus: WorkflowVersionStatus.DEACTIVATED,
+          statusUpdates: [
+            {
+              workflowId: '1',
+              previousStatus: WorkflowVersionStatus.ACTIVE,
+              newStatus: WorkflowVersionStatus.DEACTIVATED,
+            },
+          ],
         };
 
         const mockWorkflow = {
@@ -215,12 +231,16 @@ describe('WorkflowStatusesUpdate', () => {
 
       test('when WorkflowVersionStatus.DRAFT to WorkflowVersionStatus.ACTIVE, should activate', async () => {
         // Arrange
-        const event: WorkflowVersionEvent = {
+        const event: WorkflowVersionBatchEvent = {
           workspaceId: '1',
           type: WorkflowVersionEventType.STATUS_UPDATE,
-          workflowId: '1',
-          previousStatus: WorkflowVersionStatus.DRAFT,
-          newStatus: WorkflowVersionStatus.ACTIVE,
+          statusUpdates: [
+            {
+              workflowId: '1',
+              previousStatus: WorkflowVersionStatus.DRAFT,
+              newStatus: WorkflowVersionStatus.ACTIVE,
+            },
+          ],
         };
 
         const mockWorkflow = {
@@ -251,10 +271,10 @@ describe('WorkflowStatusesUpdate', () => {
     describe('when event type is DELETE', () => {
       test('when status is not draft, should not do anything', async () => {
         // Arrange
-        const event: WorkflowVersionEvent = {
+        const event: WorkflowVersionBatchEvent = {
           workspaceId: '1',
           type: WorkflowVersionEventType.DELETE,
-          workflowId: '1',
+          workflowIds: ['1'],
         };
 
         const mockWorkflow = {
@@ -273,10 +293,10 @@ describe('WorkflowStatusesUpdate', () => {
 
       test('when status is draft, should delete', async () => {
         // Arrange
-        const event: WorkflowVersionEvent = {
+        const event: WorkflowVersionBatchEvent = {
           workspaceId: '1',
           type: WorkflowVersionEventType.DELETE,
-          workflowId: '1',
+          workflowIds: ['1'],
         };
 
         const mockWorkflow = {

--- a/packages/twenty-server/src/modules/workflow/workflow-status/jobs/__tests__/workflow-statuses-update.job.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-status/jobs/__tests__/workflow-statuses-update.job.spec.ts
@@ -1,0 +1,307 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { TwentyORMManager } from 'src/engine/twenty-orm/twenty-orm.manager';
+import { WorkflowVersionStatus } from 'src/modules/workflow/common/standard-objects/workflow-version.workspace-entity';
+import { WorkflowStatus } from 'src/modules/workflow/common/standard-objects/workflow.workspace-entity';
+import {
+    WorkflowStatusesUpdateJob,
+    WorkflowVersionEvent,
+    WorkflowVersionEventType,
+} from 'src/modules/workflow/workflow-status/jobs/workflow-statuses-update.job';
+
+describe('WorkflowStatusesUpdate', () => {
+  let job: WorkflowStatusesUpdateJob;
+
+  const mockWorkflowVersionRepository = {
+    find: jest.fn(),
+  };
+
+  const mockWorkflowRepository = {
+    findOneOrFail: jest.fn(),
+    update: jest.fn(),
+  };
+
+  const mockTwentyORMManager = {
+    getRepository: jest
+      .fn()
+      .mockImplementation((name) =>
+        name === 'workflow'
+          ? mockWorkflowRepository
+          : mockWorkflowVersionRepository,
+      ),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WorkflowStatusesUpdateJob,
+        {
+          provide: TwentyORMManager,
+          useValue: mockTwentyORMManager,
+        },
+      ],
+    }).compile();
+
+    job = await module.resolve<WorkflowStatusesUpdateJob>(
+      WorkflowStatusesUpdateJob,
+    );
+  });
+
+  it('should be defined', () => {
+    expect(job).toBeDefined();
+  });
+
+  describe('handle', () => {
+    beforeEach(() => {
+      // make twentyORMManager.getRepository return a mock object
+      TwentyORMManager.prototype.getRepository = jest.fn();
+    });
+
+    describe('when event type is CREATE', () => {
+      it('when already a draft, do not change anything', async () => {
+        // Arrange
+        const event: WorkflowVersionEvent = {
+          workspaceId: '1',
+          type: WorkflowVersionEventType.CREATE,
+          workflowId: '1',
+        };
+
+        const mockWorkflow = {
+          statuses: [WorkflowStatus.DRAFT],
+        };
+
+        mockWorkflowRepository.findOneOrFail.mockResolvedValue(mockWorkflow);
+
+        // Act
+        await job.handle(event);
+
+        // Assert
+        expect(mockWorkflowRepository.findOneOrFail).toHaveBeenCalledTimes(1);
+        expect(mockWorkflowRepository.update).toHaveBeenCalledTimes(0);
+      });
+
+      it('when no draft yet, update statuses', async () => {
+        // Arrange
+        const event: WorkflowVersionEvent = {
+          workspaceId: '1',
+          type: WorkflowVersionEventType.CREATE,
+          workflowId: '1',
+        };
+
+        const mockWorkflow = {
+          statuses: [WorkflowStatus.ACTIVE],
+        };
+
+        mockWorkflowRepository.findOneOrFail.mockResolvedValue(mockWorkflow);
+
+        // Act
+        await job.handle(event);
+
+        // Assert
+        expect(mockWorkflowRepository.findOneOrFail).toHaveBeenCalledTimes(1);
+        expect(mockWorkflowRepository.update).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('when event type is STATUS_UPDATE', () => {
+      test('when status is the same, should not do anything', async () => {
+        // Arrange
+        const event: WorkflowVersionEvent = {
+          workspaceId: '1',
+          type: WorkflowVersionEventType.STATUS_UPDATE,
+          workflowId: '1',
+          previousStatus: WorkflowVersionStatus.ACTIVE,
+          newStatus: WorkflowVersionStatus.ACTIVE,
+        };
+
+        const mockWorkflow = {
+          statuses: [WorkflowStatus.ACTIVE],
+        };
+
+        mockWorkflowRepository.findOneOrFail.mockResolvedValue(mockWorkflow);
+
+        // Act
+        await job.handle(event);
+
+        // Assert
+        expect(mockWorkflowRepository.findOneOrFail).toHaveBeenCalledTimes(1);
+        expect(mockWorkflowRepository.update).toHaveBeenCalledTimes(0);
+      });
+
+      test('when update that should be impossible, do not do anything', async () => {
+        // Arrange
+        const event: WorkflowVersionEvent = {
+          workspaceId: '1',
+          type: WorkflowVersionEventType.STATUS_UPDATE,
+          workflowId: '1',
+          previousStatus: WorkflowVersionStatus.ACTIVE,
+          newStatus: WorkflowVersionStatus.DRAFT,
+        };
+
+        const mockWorkflow = {
+          statuses: [WorkflowStatus.ACTIVE],
+        };
+
+        mockWorkflowRepository.findOneOrFail.mockResolvedValue(mockWorkflow);
+
+        // Act
+        await job.handle(event);
+
+        // Assert
+        expect(mockWorkflowRepository.findOneOrFail).toHaveBeenCalledTimes(1);
+        expect(mockWorkflowRepository.update).toHaveBeenCalledTimes(0);
+      });
+
+      test('when WorkflowVersionStatus.DEACTIVATED to WorkflowVersionStatus.ACTIVE, should activate', async () => {
+        // Arrange
+        const event: WorkflowVersionEvent = {
+          workspaceId: '1',
+          type: WorkflowVersionEventType.STATUS_UPDATE,
+          workflowId: '1',
+          previousStatus: WorkflowVersionStatus.DEACTIVATED,
+          newStatus: WorkflowVersionStatus.ACTIVE,
+        };
+
+        const mockWorkflow = {
+          statuses: [WorkflowStatus.DEACTIVATED],
+        };
+
+        mockWorkflowRepository.findOneOrFail.mockResolvedValue(mockWorkflow);
+
+        // Act
+        await job.handle(event);
+
+        // Assert
+        expect(mockWorkflowRepository.findOneOrFail).toHaveBeenCalledTimes(1);
+        expect(mockWorkflowRepository.update).toHaveBeenCalledWith(
+          { id: '1' },
+          { statuses: [WorkflowStatus.ACTIVE] },
+        );
+      });
+
+      test('when WorkflowVersionStatus.ACTIVE to WorkflowVersionStatus.DEACTIVATED, should deactivate', async () => {
+        // Arrange
+        const event: WorkflowVersionEvent = {
+          workspaceId: '1',
+          type: WorkflowVersionEventType.STATUS_UPDATE,
+          workflowId: '1',
+          previousStatus: WorkflowVersionStatus.ACTIVE,
+          newStatus: WorkflowVersionStatus.DEACTIVATED,
+        };
+
+        const mockWorkflow = {
+          statuses: [WorkflowStatus.ACTIVE, WorkflowStatus.DRAFT],
+        };
+
+        mockWorkflowRepository.findOneOrFail.mockResolvedValue(mockWorkflow);
+        mockWorkflowVersionRepository.find.mockResolvedValue([]);
+
+        // Act
+        await job.handle(event);
+
+        // Assert
+        expect(mockWorkflowRepository.findOneOrFail).toHaveBeenCalledTimes(1);
+        expect(mockWorkflowVersionRepository.find).toHaveBeenCalledWith({
+          where: {
+            workflowId: '1',
+            status: WorkflowVersionStatus.ACTIVE,
+          },
+        });
+        expect(mockWorkflowRepository.update).toHaveBeenCalledWith(
+          { id: '1' },
+          { statuses: [WorkflowStatus.DEACTIVATED, WorkflowStatus.DRAFT] },
+        );
+      });
+
+      test('when WorkflowVersionStatus.DRAFT to WorkflowVersionStatus.ACTIVE, should activate', async () => {
+        // Arrange
+        const event: WorkflowVersionEvent = {
+          workspaceId: '1',
+          type: WorkflowVersionEventType.STATUS_UPDATE,
+          workflowId: '1',
+          previousStatus: WorkflowVersionStatus.DRAFT,
+          newStatus: WorkflowVersionStatus.ACTIVE,
+        };
+
+        const mockWorkflow = {
+          statuses: [WorkflowStatus.DRAFT],
+        };
+
+        mockWorkflowRepository.findOneOrFail.mockResolvedValue(mockWorkflow);
+        mockWorkflowVersionRepository.find.mockResolvedValue([]);
+
+        // Act
+        await job.handle(event);
+
+        // Assert
+        expect(mockWorkflowRepository.findOneOrFail).toHaveBeenCalledTimes(1);
+        expect(mockWorkflowVersionRepository.find).toHaveBeenCalledWith({
+          where: {
+            workflowId: '1',
+            status: WorkflowVersionStatus.DRAFT,
+          },
+        });
+        expect(mockWorkflowRepository.update).toHaveBeenCalledWith(
+          { id: '1' },
+          { statuses: [WorkflowStatus.ACTIVE] },
+        );
+      });
+    });
+
+    describe('when event type is DELETE', () => {
+      test('when status is not draft, should not do anything', async () => {
+        // Arrange
+        const event: WorkflowVersionEvent = {
+          workspaceId: '1',
+          type: WorkflowVersionEventType.DELETE,
+          workflowId: '1',
+        };
+
+        const mockWorkflow = {
+          statuses: [WorkflowStatus.ACTIVE],
+        };
+
+        mockWorkflowRepository.findOneOrFail.mockResolvedValue(mockWorkflow);
+
+        // Act
+        await job.handle(event);
+
+        // Assert
+        expect(mockWorkflowRepository.findOneOrFail).toHaveBeenCalledTimes(1);
+        expect(mockWorkflowRepository.update).toHaveBeenCalledTimes(0);
+      });
+
+      test('when status is draft, should delete', async () => {
+        // Arrange
+        const event: WorkflowVersionEvent = {
+          workspaceId: '1',
+          type: WorkflowVersionEventType.DELETE,
+          workflowId: '1',
+        };
+
+        const mockWorkflow = {
+          statuses: [WorkflowStatus.DRAFT],
+        };
+
+        mockWorkflowRepository.findOneOrFail.mockResolvedValue(mockWorkflow);
+        mockWorkflowVersionRepository.find.mockResolvedValue([]);
+
+        // Act
+        await job.handle(event);
+
+        // Assert
+        expect(mockWorkflowRepository.findOneOrFail).toHaveBeenCalledTimes(1);
+        expect(mockWorkflowVersionRepository.find).toHaveBeenCalledWith({
+          where: {
+            workflowId: '1',
+            status: WorkflowVersionStatus.DRAFT,
+          },
+        });
+        expect(mockWorkflowRepository.update).toHaveBeenCalledWith(
+          { id: '1' },
+          { statuses: [] },
+        );
+      });
+    });
+  });
+});

--- a/packages/twenty-server/src/modules/workflow/workflow-status/jobs/workflow-statuses-update.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-status/jobs/workflow-statuses-update.job.ts
@@ -2,6 +2,7 @@ import { Scope } from '@nestjs/common';
 
 import isEqual from 'lodash.isequal';
 
+import { Process } from 'src/engine/integrations/message-queue/decorators/process.decorator';
 import { Processor } from 'src/engine/integrations/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/integrations/message-queue/message-queue.constants';
 import { TwentyORMManager } from 'src/engine/twenty-orm/twenty-orm.manager';
@@ -34,7 +35,7 @@ export type WorkflowVersionBatchCreateEvent = {
   workflowIds: string[];
 };
 
-type WorkflowVersionStatusUpdate = {
+export type WorkflowVersionStatusUpdate = {
   workflowId: string;
   previousStatus: WorkflowVersionStatus;
   newStatus: WorkflowVersionStatus;
@@ -54,6 +55,7 @@ export type WorkflowVersionBatchDelete = {
 export class WorkflowStatusesUpdateJob {
   constructor(private readonly twentyORMManager: TwentyORMManager) {}
 
+  @Process(WorkflowStatusesUpdateJob.name)
   async handle(event: WorkflowVersionBatchEvent): Promise<void> {
     switch (event.type) {
       case WorkflowVersionEventType.CREATE:

--- a/packages/twenty-server/src/modules/workflow/workflow-status/jobs/workflow-statuses-update.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-status/jobs/workflow-statuses-update.job.ts
@@ -1,6 +1,6 @@
 import { Scope } from '@nestjs/common';
 
-import _ from 'lodash';
+import { isEqual } from 'lodash';
 
 import { Processor } from 'src/engine/integrations/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/integrations/message-queue/message-queue.constants';
@@ -136,7 +136,7 @@ export class WorkflowStatusesUpdateJob {
     const newWorkflowStatusesArray = Array.from(newWorkflowStatuses);
 
     if (
-      _.isEqual(newWorkflowStatusesArray.sort(), currentWorkflowStatuses.sort())
+      isEqual(newWorkflowStatusesArray.sort(), currentWorkflowStatuses.sort())
     ) {
       return;
     }

--- a/packages/twenty-server/src/modules/workflow/workflow-status/jobs/workflow-statuses-update.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-status/jobs/workflow-statuses-update.job.ts
@@ -1,0 +1,256 @@
+import { Scope } from '@nestjs/common';
+
+import _ from 'lodash';
+
+import { Processor } from 'src/engine/integrations/message-queue/decorators/processor.decorator';
+import { MessageQueue } from 'src/engine/integrations/message-queue/message-queue.constants';
+import { TwentyORMManager } from 'src/engine/twenty-orm/twenty-orm.manager';
+import {
+  WorkflowVersionStatus,
+  WorkflowVersionWorkspaceEntity,
+} from 'src/modules/workflow/common/standard-objects/workflow-version.workspace-entity';
+import {
+  WorkflowStatus,
+  WorkflowWorkspaceEntity,
+} from 'src/modules/workflow/common/standard-objects/workflow.workspace-entity';
+
+export enum WorkflowVersionEventType {
+  CREATE = 'CREATE',
+  STATUS_UPDATE = 'STATUS_UPDATE',
+  DELETE = 'DELETE',
+}
+
+export type WorkflowVersionEvent = { workspaceId: string } & (
+  | WorkflowVersionCreated
+  | WorkflowVersionStatusUpdate
+  | WorkflowVersionDeleted
+);
+
+export type WorkflowVersionCreated = {
+  type: WorkflowVersionEventType.CREATE;
+  workflowId: string;
+};
+
+export type WorkflowVersionStatusUpdate = {
+  type: WorkflowVersionEventType.STATUS_UPDATE;
+  workflowId: string;
+  previousStatus: WorkflowVersionStatus;
+  newStatus: WorkflowVersionStatus;
+};
+
+export type WorkflowVersionDeleted = {
+  type: WorkflowVersionEventType.DELETE;
+  workflowId: string;
+};
+
+@Processor({ queueName: MessageQueue.workflowQueue, scope: Scope.REQUEST })
+export class WorkflowStatusesUpdateJob {
+  constructor(private readonly twentyORMManager: TwentyORMManager) {}
+
+  async handle(event: WorkflowVersionEvent): Promise<void> {
+    switch (event.type) {
+      case WorkflowVersionEventType.CREATE:
+        return this.handleWorkflowVersionCreated(event);
+      case WorkflowVersionEventType.STATUS_UPDATE:
+        return this.handleWorkflowVersionStatusUpdated(event);
+      case WorkflowVersionEventType.DELETE:
+        return this.handleWorkflowVersionDeleted(event);
+    }
+  }
+
+  private async handleWorkflowVersionCreated(
+    event: WorkflowVersionCreated,
+  ): Promise<void> {
+    const workflowRepository =
+      await this.twentyORMManager.getRepository<WorkflowWorkspaceEntity>(
+        'workflow',
+      );
+
+    const workflow = await workflowRepository.findOneOrFail({
+      where: {
+        id: event.workflowId,
+      },
+    });
+
+    const currentWorkflowStatuses = workflow.statuses || [];
+
+    if (currentWorkflowStatuses.includes(WorkflowStatus.DRAFT)) {
+      return;
+    }
+
+    await workflowRepository.update(
+      {
+        id: workflow.id,
+      },
+      {
+        statuses: [...currentWorkflowStatuses, WorkflowStatus.DRAFT],
+      },
+    );
+  }
+
+  private async handleWorkflowVersionStatusUpdated(
+    event: WorkflowVersionStatusUpdate,
+  ): Promise<void> {
+    const workflowRepository =
+      await this.twentyORMManager.getRepository<WorkflowWorkspaceEntity>(
+        'workflow',
+      );
+
+    const workflow = await workflowRepository.findOneOrFail({
+      where: {
+        id: event.workflowId,
+      },
+    });
+
+    const currentWorkflowStatuses = workflow.statuses || [];
+    let newWorkflowStatuses = new Set<WorkflowStatus>(currentWorkflowStatuses);
+
+    if (
+      event.previousStatus === WorkflowVersionStatus.DEACTIVATED &&
+      event.newStatus === WorkflowVersionStatus.ACTIVE
+    ) {
+      newWorkflowStatuses = await this.buildStatusesFromNewActivation(
+        currentWorkflowStatuses,
+      );
+    }
+
+    if (
+      event.previousStatus === WorkflowVersionStatus.ACTIVE &&
+      event.newStatus === WorkflowVersionStatus.DEACTIVATED
+    ) {
+      newWorkflowStatuses = await this.buildStatusesFromDeactivation(
+        event.workflowId,
+        currentWorkflowStatuses,
+      );
+    }
+
+    if (
+      event.previousStatus === WorkflowVersionStatus.DRAFT &&
+      event.newStatus === WorkflowVersionStatus.ACTIVE
+    ) {
+      newWorkflowStatuses = await this.buildStatusesFromFirstActivation(
+        event.workflowId,
+      );
+    }
+
+    const newWorkflowStatusesArray = Array.from(newWorkflowStatuses);
+
+    if (
+      _.isEqual(newWorkflowStatusesArray.sort(), currentWorkflowStatuses.sort())
+    ) {
+      return;
+    }
+
+    await workflowRepository.update(
+      {
+        id: event.workflowId,
+      },
+      {
+        statuses: newWorkflowStatusesArray,
+      },
+    );
+  }
+
+  private async handleWorkflowVersionDeleted(
+    event: WorkflowVersionDeleted,
+  ): Promise<void> {
+    const workflowRepository =
+      await this.twentyORMManager.getRepository<WorkflowWorkspaceEntity>(
+        'workflow',
+      );
+
+    const workflow = await workflowRepository.findOneOrFail({
+      where: {
+        id: event.workflowId,
+      },
+    });
+
+    const currentWorkflowStatuses = workflow.statuses || [];
+
+    if (!currentWorkflowStatuses.includes(WorkflowStatus.DRAFT)) {
+      return;
+    }
+
+    const hasWorkflowVersionByStatus = await this.hasWorkflowVersionByStatus(
+      event.workflowId,
+      WorkflowVersionStatus.DRAFT,
+    );
+
+    if (hasWorkflowVersionByStatus) {
+      return;
+    }
+
+    await workflowRepository.update(
+      {
+        id: event.workflowId,
+      },
+      {
+        statuses: currentWorkflowStatuses.filter(
+          (status) => status !== WorkflowStatus.DRAFT,
+        ),
+      },
+    );
+  }
+
+  private async buildStatusesFromFirstActivation(workflowId: string) {
+    const hasWorkflowVersionDraft = await this.hasWorkflowVersionByStatus(
+      workflowId,
+      WorkflowVersionStatus.DRAFT,
+    );
+
+    if (hasWorkflowVersionDraft) {
+      return new Set([WorkflowStatus.ACTIVE, WorkflowStatus.DRAFT]);
+    }
+
+    return new Set([WorkflowStatus.ACTIVE]);
+  }
+
+  private async buildStatusesFromDeactivation(
+    workflowId: string,
+    currentWorkflowStatuses: WorkflowStatus[],
+  ) {
+    const hasWorkflowVersionActive = await this.hasWorkflowVersionByStatus(
+      workflowId,
+      WorkflowVersionStatus.ACTIVE,
+    );
+
+    if (hasWorkflowVersionActive) {
+      return new Set(currentWorkflowStatuses);
+    }
+
+    return new Set(
+      currentWorkflowStatuses
+        .filter((status) => status !== WorkflowStatus.ACTIVE)
+        .concat(WorkflowStatus.DEACTIVATED),
+    );
+  }
+
+  private async buildStatusesFromNewActivation(
+    currentWorkflowStatuses: WorkflowStatus[],
+  ) {
+    return new Set(
+      currentWorkflowStatuses
+        .filter((status) => status !== WorkflowStatus.DEACTIVATED)
+        .concat(WorkflowStatus.ACTIVE),
+    );
+  }
+
+  private async hasWorkflowVersionByStatus(
+    workflowId: string,
+    status: WorkflowVersionStatus,
+  ): Promise<boolean> {
+    const workflowVersionRepository =
+      await this.twentyORMManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        'workflowVersion',
+      );
+
+    const workflowVersions = await workflowVersionRepository.find({
+      where: {
+        workflowId,
+        status,
+      },
+    });
+
+    return workflowVersions.length > 0;
+  }
+}

--- a/packages/twenty-server/src/modules/workflow/workflow-status/listeners/workflow-version-status.listener.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-status/listeners/workflow-version-status.listener.ts
@@ -1,0 +1,85 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+
+import { ObjectRecordCreateEvent } from 'src/engine/integrations/event-emitter/types/object-record-create.event';
+import { ObjectRecordUpdateEvent } from 'src/engine/integrations/event-emitter/types/object-record-update.event';
+import { InjectMessageQueue } from 'src/engine/integrations/message-queue/decorators/message-queue.decorator';
+import { MessageQueue } from 'src/engine/integrations/message-queue/message-queue.constants';
+import { MessageQueueService } from 'src/engine/integrations/message-queue/services/message-queue.service';
+import {
+  WorkflowVersionStatus,
+  WorkflowVersionWorkspaceEntity,
+} from 'src/modules/workflow/common/standard-objects/workflow-version.workspace-entity';
+import {
+  WorkflowStatusesUpdateJob,
+  WorkflowVersionEvent,
+  WorkflowVersionEventType,
+} from 'src/modules/workflow/workflow-status/jobs/workflow-statuses-update.job';
+
+@Injectable()
+export class WorkflowVersionStatusListener {
+  private readonly logger = new Logger(WorkflowVersionStatusListener.name);
+
+  constructor(
+    @InjectMessageQueue(MessageQueue.workflowQueue)
+    private readonly messageQueueService: MessageQueueService,
+  ) {}
+
+  @OnEvent('workflowVersion.created')
+  async handleWorkflowVersionCreated(
+    event: ObjectRecordCreateEvent<WorkflowVersionWorkspaceEntity>,
+  ): Promise<void> {
+    await this.messageQueueService.add<WorkflowVersionEvent>(
+      WorkflowStatusesUpdateJob.name,
+      {
+        type: WorkflowVersionEventType.CREATE,
+        workflowId: event.properties.after.workflowId,
+      },
+    );
+  }
+
+  @OnEvent('workflowVersion.updated')
+  async handleWorkflowVersionUpdated(
+    event: ObjectRecordUpdateEvent<WorkflowVersionWorkspaceEntity>,
+  ): Promise<void> {
+    const workflowVersionBefore = event.properties.before;
+    const workflowVersionAfter = event.properties.after;
+
+    if (workflowVersionBefore.status === workflowVersionAfter.status) {
+      return;
+    }
+
+    await this.messageQueueService.add<WorkflowVersionEvent>(
+      WorkflowStatusesUpdateJob.name,
+      {
+        type: WorkflowVersionEventType.STATUS_UPDATE,
+        workflowId: workflowVersionAfter.workflowId,
+        previousStatus: workflowVersionBefore.status,
+        newStatus: workflowVersionAfter.status,
+      },
+    );
+  }
+
+  @OnEvent('workflowVersion.deleted')
+  async handleWorkflowVersionDeleted(
+    event: ObjectRecordCreateEvent<WorkflowVersionWorkspaceEntity>,
+  ): Promise<void> {
+    const workflowVersionDeleted = event.properties.after;
+
+    if (workflowVersionDeleted.status !== WorkflowVersionStatus.DRAFT) {
+      this.logger.warn(
+        `Workflow version ${event.recordId} with status ${workflowVersionDeleted.status} was deleted.`,
+      );
+
+      return;
+    }
+
+    await this.messageQueueService.add<WorkflowVersionEvent>(
+      WorkflowStatusesUpdateJob.name,
+      {
+        type: WorkflowVersionEventType.DELETE,
+        workflowId: workflowVersionDeleted.workflowId,
+      },
+    );
+  }
+}

--- a/packages/twenty-server/src/modules/workflow/workflow-status/workflow-status.module.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-status/workflow-status.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+
+import { WorkflowStatusesUpdateJob } from 'src/modules/workflow/workflow-status/jobs/workflow-statuses-update.job';
+import { WorkflowVersionStatusListener } from 'src/modules/workflow/workflow-status/listeners/workflow-version-status.listener';
+
+@Module({
+  providers: [WorkflowStatusesUpdateJob, WorkflowVersionStatusListener],
+})
+export class WorkflowStatusModule {}

--- a/packages/twenty-server/src/modules/workflow/workflow.module.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 
+import { WorkflowStatusModule } from 'src/modules/workflow/workflow-status/workflow-status.module';
 import { WorkflowTriggerModule } from 'src/modules/workflow/workflow-trigger/workflow-trigger.module';
 
 @Module({
-  imports: [WorkflowTriggerModule],
+  imports: [WorkflowTriggerModule, WorkflowStatusModule],
 })
 export class WorkflowModule {}


### PR DESCRIPTION
Add listener to keep status on workflows up to date:
• version draft => statuses should contain draft
• version active => statuses should contain active 
• version deactivated => if no version active, statuses should contain deactivated
Renaming also the endpoints because it was not reflecting the full behaviour.
Finally, adding a new status Archived for versions. Will be used when a version is deactivated, but is not the last published version anymore. It means this version cannot be re-activated.